### PR TITLE
fix: enable google analytics in production

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: shreve.dev
-environment: development
+environment: production # !FIX! i think this is a no-op, controlled by JEKYLL_ENV variable
 
 author: 
   name: Eric Shreve

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,9 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){window.dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>


### PR DESCRIPTION
set JEKYLL_ENV=production in cloudflare pages deplooyment environment